### PR TITLE
Fix kubesec error handling

### DIFF
--- a/vessel/tools/kubesec.py
+++ b/vessel/tools/kubesec.py
@@ -4,7 +4,7 @@ import logging
 from ..models import Issue, Context
 from ..manager import vessel_hook, vessel_result
 from io import StringIO
-from sh import kubesec, ErrorReturnCode
+from sh import kubesec, ErrorReturnCode_2
 
 logger = logging.getLogger(__name__)
 
@@ -15,14 +15,14 @@ def resource_kubesec(k8s_object):
 
   try:
     kubesec("scan", "-", _in=specyaml, _out=result)
-  except BaseException:
+  except ErrorReturnCode_2:
     report = json.loads(result.getvalue())[0] # we examine one at the time always
     # todo: we use advise ?
     # for v in report['scoring'].get('advise', []):
     #   issues.append(Issue(name=f'{v["id"]}', metadata=v))
     for v in report['scoring'].get('critical', []):
       issues.append(Issue(name=f'{v["id"]}', metadata=v))
-  except ErrorReturnCode:
+  except BaseException:
     logger.error("Unable to execute kubescan")
   
   return issues


### PR DESCRIPTION
We need to differentiate the error handling for kubesec. We need to
consider ErrorReturnCode_2 as the error that says there are
problems with the yaml, and then consider BaseException for all the
other kind of problems.